### PR TITLE
rmi.hostname property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.hibernate:hibernate-core:5.6.5.Final'
     implementation 'org.hibernate:hibernate-search-orm:5.11.10.Final'
     implementation 'org.postgresql:postgresql:42.3.3'
-    implementation 'com.github.TeamF-SS22-SEM4:RMI-Shared-Lib:v9'
+    implementation 'com.github.TeamF-SS22-SEM4:RMI-Shared-Lib:v10'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'com.h2database:h2:2.1.210'
     implementation "org.mockito:mockito-core:3.+" //TODO change to testImpl when InstanceProvider doesn't mock anymore

--- a/src/main/java/at/fhv/ss22/ea/f/musicshop/backend/communication/RMIServer.java
+++ b/src/main/java/at/fhv/ss22/ea/f/musicshop/backend/communication/RMIServer.java
@@ -10,20 +10,21 @@ import java.rmi.registry.LocateRegistry;
 public class RMIServer {
     private static int PORT = Integer.parseInt(System.getenv("RMI_PORT"));
     private static String PROTOCOL = "rmi://";
-    private static String HOST = "localhost";
+    private static String RMI_REGISTRY_HOST = "localhost"; // NOTE: this value doesn't have the same
+    // purpose as the "RMI_HOST" environment variable
     private static String REMOTE_OBJECT_NAME = "RMIFactory";
 
     public static int getPort() {return PORT;}
 
     public static void startRMIServer() {
         try {
-            System.setProperty("java.rmi.server.hostname", HOST);
+            //needed because else stub-endpoints are bound to the standard docker ip-network (172.- something)
+            // which makes our remote objects then unreachable
+            System.setProperty("java.rmi.server.hostname", System.getenv("RMI_HOSTNAME"));
 
             RMIFactory rmiFactory = new RMIFactoryImpl(PORT);
-
             LocateRegistry.createRegistry(PORT);
-
-            Naming.rebind(PROTOCOL + HOST + ":" + PORT + "/" + REMOTE_OBJECT_NAME, rmiFactory);
+            Naming.rebind(PROTOCOL + RMI_REGISTRY_HOST + ":" + PORT + "/" + REMOTE_OBJECT_NAME, rmiFactory);
 
             System.out.println("RMIFactory bound in registry on port " + PORT);
         } catch (RemoteException | MalformedURLException e) {


### PR DESCRIPTION
rmi.hostname property is now again read from environment variable, should solve issue of refused connection to server from FxClient